### PR TITLE
fix: set value for token when opala is disabled

### DIFF
--- a/helm/raster/config/nginx.conf
+++ b/helm/raster/config/nginx.conf
@@ -43,7 +43,11 @@ http {
         '},'
         #'"TraceId": "$opentelemetry_trace_id",' ## this is a byte sequence (hex-encoded in JSON)
         #'"SpanId": "$opentelemetry_span_id",'
+        {{ if .Values.nginx.authorization.enabled }}
         '"TokenUser": "$jwt_payload_sub",'
+        {{ else }}
+        '"TokenUser": "NoAuth",'
+        {{ end }}
         '"SeverityText": "INFO",'
         '"SeverityNumber": 9,'
         '"RequestBody": "$request_body",'


### PR DESCRIPTION
# Overview
This PR solves the bug when opala is disabled and set some string ("NoAuth" in this case) to TokenUser log

# Related Issue / Discussion
#50 