### PR TITLE
chore: remove layerpoly parts, included_in_best and discretes

### DIFF
--- a/helm/raster/config/mappings.py
+++ b/helm/raster/config/mappings.py
@@ -56,8 +56,5 @@ MD_CORE_MODEL = {
         # Added for mc-raster 
         'pycsw:Rms': 'rms',
         'pycsw:Scale': 'scale',
-        'pycsw:layerPolygonParts': 'layer_polygon_parts',
-        'pycsw:includedInBests': 'included_in_bests',
-        'pycsw:discretes': 'discretes',
     }
 }

--- a/pycsw/plugins/profiles/mc_raster/mc_raster.py
+++ b/pycsw/plugins/profiles/mc_raster/mc_raster.py
@@ -51,9 +51,6 @@ class MCRaster(base_profile.base_profile):
                         'mc:keywords': Queryable(context.md_core_model['mappings']['pycsw:Keywords'], 'mc:keywords'),
                         'mc:RMS': Queryable(context.md_core_model['mappings']['pycsw:Rms'], 'mc:RMS'),
                         'mc:scale': Queryable(context.md_core_model['mappings']['pycsw:Scale'], 'mc:scale'),
-                        'mc:layerPolygonParts': Queryable(context.md_core_model['mappings']['pycsw:layerPolygonParts'], 'mc:layerPolygonParts'),
-                        'mc:includedInBests': Queryable(context.md_core_model['mappings']['pycsw:includedInBests'], 'mc:includedInBests'),
-                        'mc:discretes': Queryable(context.md_core_model['mappings']['pycsw:discretes'], 'mc:discretes'),
                         'mc:productBBox': Queryable(context.md_core_model['mappings']['pycsw:productBBox'], 'mc:productBBox'),
                         'mc:transparency': Queryable(context.md_core_model['mappings']['pycsw:transparency'], 'mc:transparency'),
                     }

--- a/pycsw/plugins/profiles/mc_raster/schemas/mcraster-record.xsd
+++ b/pycsw/plugins/profiles/mc_raster/schemas/mcraster-record.xsd
@@ -74,9 +74,6 @@
                <xsd:element ref="mc:region" />
                <xsd:element ref="mc:RMS" />
                <xsd:element ref="mc:scale" />
-               <xsd:element ref="mc:layerPolygonParts" />
-               <xsd:element ref="mc:includedInBests" />
-               <xsd:element ref="mc:discretes" />
                <xsd:element ref="mc:productBBox" />
             </xsd:sequence>
          </xsd:extension>


### PR DESCRIPTION
this is from base version v4.3.7 without 'OPALA'