### PR TITLE
chore: upgrade helm version

### DIFF
--- a/helm/raster/Chart.yaml
+++ b/helm/raster/Chart.yaml
@@ -2,8 +2,8 @@ apiVersion: v2
 name: pycsw
 description: A Helm chart for pycsw service
 type: application
-version: 4.5.0
-appVersion: 4.5.0
+version: 4.5.1
+appVersion: 4.5.1
 dependencies:
   - name: nginx
     version: 1.1.0


### PR DESCRIPTION
# Overview
Upgraded the raster helm version to match the project tag (4.5.1)