### PR TITLE
helm: infra labels and annotations in raster pycsw MAPCO-9060

### DIFF
--- a/helm/raster/Chart.yaml
+++ b/helm/raster/Chart.yaml
@@ -2,8 +2,8 @@ apiVersion: v2
 name: pycsw
 description: A Helm chart for pycsw service
 type: application
-version: 6.0.1
-appVersion: 6.0.1
+version: 6.1.0
+appVersion: 6.1.0
 dependencies:
   - name: nginx
     version: 1.1.0

--- a/helm/raster/Chart.yaml
+++ b/helm/raster/Chart.yaml
@@ -8,7 +8,6 @@ dependencies:
   - name: nginx
     version: 1.1.0
     repository: oci://acrarolibotnonprod.azurecr.io/helm
-  - name: mc-labels-and-annotations
-    version: 0.5.1
+  - name: mclabels
+    version: 1.0.1
     repository: oci://acrarolibotnonprod.azurecr.io/helm/infra
-    alias: mcLabelsAndAnnotations

--- a/helm/raster/Chart.yaml
+++ b/helm/raster/Chart.yaml
@@ -2,8 +2,8 @@ apiVersion: v2
 name: pycsw
 description: A Helm chart for pycsw service
 type: application
-version: 6.1.0
-appVersion: 6.1.0
+version: 6.2.2
+appVersion: 6.2.2
 dependencies:
   - name: nginx
     version: 1.1.0

--- a/helm/raster/Chart.yaml
+++ b/helm/raster/Chart.yaml
@@ -8,3 +8,7 @@ dependencies:
   - name: nginx
     version: 1.1.0
     repository: oci://acrarolibotnonprod.azurecr.io/helm
+  - name: mc-labels-and-annotations
+    version: 0.5.1
+    repository: oci://acrarolibotnonprod.azurecr.io/helm/infra
+    alias: mcLabelsAndAnnotations

--- a/helm/raster/templates/_helpers.tpl
+++ b/helm/raster/templates/_helpers.tpl
@@ -36,7 +36,7 @@ helm.sh/chart: {{ include "pycsw.chart" . }}
 app.kubernetes.io/version: {{ .Chart.AppVersion | quote }}
 {{- end }}
 app.kubernetes.io/managed-by: {{ .Release.Service }}
-{{ include "mc-labels-and-annotations.labels" . }}
+{{ include "mclabels.labels" . }}
 {{- end }}
 
 {{/*
@@ -52,7 +52,7 @@ Selector labels
 {{- define "pycsw.selectorLabels" -}}
 app.kubernetes.io/name: {{ include "pycsw.name" . }}
 app.kubernetes.io/instance: {{ .Release.Name }}
-{{ include "mc-labels-and-annotations.selectorLabels" . }}
+{{ include "mclabels.selectorLabels" . }}
 {{- end }}
 
 {{/*

--- a/helm/raster/templates/_helpers.tpl
+++ b/helm/raster/templates/_helpers.tpl
@@ -36,6 +36,7 @@ helm.sh/chart: {{ include "pycsw.chart" . }}
 app.kubernetes.io/version: {{ .Chart.AppVersion | quote }}
 {{- end }}
 app.kubernetes.io/managed-by: {{ .Release.Service }}
+{{ include "mc-labels-and-annotations.labels" . }}
 {{- end }}
 
 {{/*
@@ -51,6 +52,7 @@ Selector labels
 {{- define "pycsw.selectorLabels" -}}
 app.kubernetes.io/name: {{ include "pycsw.name" . }}
 app.kubernetes.io/instance: {{ .Release.Name }}
+{{ include "mc-labels-and-annotations.selectorLabels" . }}
 {{- end }}
 
 {{/*

--- a/helm/raster/templates/deployment.yaml
+++ b/helm/raster/templates/deployment.yaml
@@ -47,7 +47,6 @@ spec:
         run: {{ $releaseName }}-{{ $chartName }}
         {{- include "pycsw.selectorLabels" . | nindent 8 }}
       annotations:
-        {{ include "mc-labels-and-annotations.annotations" . | nindent 8 }}
         {{- if .Values.resetOnConfigChange }}
         checksum/configmap: {{ include (print $.Template.BasePath "/configmap.yaml") . | sha256sum }}
         {{- end }}
@@ -58,6 +57,7 @@ spec:
         {{- if .Values.podAnnotations }}
         {{- toYaml .Values.podAnnotations | nindent 8 }}
         {{- end }}
+        {{ include "mclabels.annotations" . | nindent 8 }}
     spec:
     {{- if $cloudProviderImagePullSecretName }}
       imagePullSecrets:

--- a/helm/raster/templates/deployment.yaml
+++ b/helm/raster/templates/deployment.yaml
@@ -50,14 +50,11 @@ spec:
         {{- if .Values.resetOnConfigChange }}
         checksum/configmap: {{ include (print $.Template.BasePath "/configmap.yaml") . | sha256sum }}
         {{- end }}
-        {{- if .Values.env.metrics.enabled }}
-        prometheus.io/port: {{ .Values.env.metrics.prometheus.port | quote }}
-        prometheus.io/scrape: {{ .Values.env.metrics.prometheus.scrape | quote }}
-        {{- end }}
         {{- if .Values.podAnnotations }}
         {{- toYaml .Values.podAnnotations | nindent 8 }}
         {{- end }}
         {{ include "mclabels.annotations" . | nindent 8 }}
+
     spec:
     {{- if $cloudProviderImagePullSecretName }}
       imagePullSecrets:

--- a/helm/raster/templates/deployment.yaml
+++ b/helm/raster/templates/deployment.yaml
@@ -47,6 +47,7 @@ spec:
         run: {{ $releaseName }}-{{ $chartName }}
         {{- include "pycsw.selectorLabels" . | nindent 8 }}
       annotations:
+        {{ include "mc-labels-and-annotations.annotations" . | nindent 8 }}
         {{- if .Values.resetOnConfigChange }}
         checksum/configmap: {{ include (print $.Template.BasePath "/configmap.yaml") . | sha256sum }}
         {{- end }}

--- a/helm/raster/values.yaml
+++ b/helm/raster/values.yaml
@@ -23,8 +23,8 @@ global:
       caFileKey: ""
       certFileKey: ""
       keyFileKey: ""
-  mc-labels-and-annotations:
-    environment: ""    
+  mcLabelsAndAnnotations:
+    environment: ""
 
 enabled: true
 environment: development
@@ -73,8 +73,8 @@ servicePort: 8080
 # annotation2: annotation-value-2
 podAnnotations: {}
 
-mc-labels-and-annotations:
-  environment: ""
+mcLabelsAndAnnotations:
+  environment: "development"
   owner: 'raster'
   component: backend
   partOf: raster-serving
@@ -88,8 +88,7 @@ env:
   logfile: ""
   profiles: mc_raster
   logFormat: >-
-    %(h)s %(l)s %(u)s %(t)s "%(r)s" %(s)s %(b)s "%(f)s" "%(a)s"
-    %({x-forwarded-for}i)s %(L)s
+    %(h)s %(l)s %(u)s %(t)s "%(r)s" %(s)s %(b)s "%(f)s" "%(a)s" %({x-forwarded-for}i)s %(L)s
   uwsgi:
     processes: 6
     threads: 10
@@ -131,7 +130,7 @@ nginx:
   image:
     repository: nginx-otel-unprivileged
     tag: "v1.0.0"
-  
+
   port: 8080
   internalServicePort: 80
   nginxTargetPort: 8080
@@ -146,20 +145,20 @@ nginx:
       queryName: token
 
   extraVolumes:
-    - name: nginx-config
-      configMap:
-        name: "{{ .Release.Name }}-pycsw-nginx-configmap"
+  - name: nginx-config
+    configMap:
+      name: "{{ .Release.Name }}-pycsw-nginx-configmap"
 
   extraVolumeMounts:
-    - name: nginx-config
-      mountPath: "/etc/nginx/conf.d/default.conf"
-      subPath: default.conf
-    - mountPath: "/etc/nginx/nginx.conf"
-      name: nginx-config
-      subPath: nginx.conf
-    - name: nginx-config
-      mountPath: "/etc/nginx/log_format.conf"
-      subPath: log_format.conf
+  - name: nginx-config
+    mountPath: "/etc/nginx/conf.d/default.conf"
+    subPath: default.conf
+  - mountPath: "/etc/nginx/nginx.conf"
+    name: nginx-config
+    subPath: nginx.conf
+  - name: nginx-config
+    mountPath: "/etc/nginx/log_format.conf"
+    subPath: log_format.conf
 
   resources:
     enabled: true

--- a/helm/raster/values.yaml
+++ b/helm/raster/values.yaml
@@ -30,6 +30,10 @@ mclabels:
   partOf: serving
   owner: raster
   gisDomain: raster
+  prometheus:
+    enabled: true
+    port: 9117
+  longScraping: true
 
 enabled: true
 environment: development

--- a/helm/raster/values.yaml
+++ b/helm/raster/values.yaml
@@ -74,7 +74,7 @@ servicePort: 8080
 podAnnotations: {}
 
 mcLabelsAndAnnotations:
-  environment: "development"
+  environment: ""
   owner: 'raster'
   component: backend
   partOf: raster-serving

--- a/helm/raster/values.yaml
+++ b/helm/raster/values.yaml
@@ -24,7 +24,12 @@ global:
       certFileKey: ""
       keyFileKey: ""
   mcLabelsAndAnnotations:
-    environment: ""
+    environment: "development"
+
+mcLabelsAndAnnotations:
+  owner: 'raster'
+  component: backend
+  partOf: raster-serving
 
 enabled: true
 environment: development
@@ -72,12 +77,6 @@ servicePort: 8080
 # annotation1: annotation-value-1
 # annotation2: annotation-value-2
 podAnnotations: {}
-
-mcLabelsAndAnnotations:
-  environment: ""
-  owner: 'raster'
-  component: backend
-  partOf: raster-serving
 
 filterProductStatus: false
 

--- a/helm/raster/values.yaml
+++ b/helm/raster/values.yaml
@@ -23,13 +23,13 @@ global:
       caFileKey: ""
       certFileKey: ""
       keyFileKey: ""
-  mcLabelsAndAnnotations:
-    environment: "development"
 
-mcLabelsAndAnnotations:
-  owner: 'raster'
+mclabels:
+  #environment: development
   component: backend
-  partOf: raster-serving
+  partOf: serving
+  owner: raster
+  gisDomain: raster
 
 enabled: true
 environment: development

--- a/helm/raster/values.yaml
+++ b/helm/raster/values.yaml
@@ -23,6 +23,8 @@ global:
       caFileKey: ""
       certFileKey: ""
       keyFileKey: ""
+  mc-labels-and-annotations:
+    environment: ""    
 
 enabled: true
 environment: development
@@ -70,6 +72,12 @@ servicePort: 8080
 # annotation1: annotation-value-1
 # annotation2: annotation-value-2
 podAnnotations: {}
+
+mc-labels-and-annotations:
+  environment: ""
+  owner: 'raster'
+  component: backend
+  partOf: raster-serving
 
 filterProductStatus: false
 


### PR DESCRIPTION
NOTE:! Do not merge! There is a bug with selector-labels in the annotation helm package. 
Wait for an update from @netanelC , upgarde the annotation dependency. Then pack the package locally, deploy using helm charts and only then merge and upgrade the helm-charts repo according to the new tag.
@CL-SHLOMIKONCHA 
Implemented infra labels and annotations in raster pycsw helm