### PR TITLE
fix: added stable-sort key for raster helm (MAPCO-8533)

### DIFF
--- a/helm/raster/config/pycsw.cfg
+++ b/helm/raster/config/pycsw.cfg
@@ -61,6 +61,7 @@ table=${DB_SCHEMA}.records
 {{- if .Values.filterProductStatus }}
 filter=product_status != 'UNPUBLISHED'
 {{- end }}
+stable_sort=true
 
 [metadata:inspire]
 #enabled=true


### PR DESCRIPTION
Added `stable-sort` to raster helm
