### PR TITLE
feat(helm): upgrade raster nginx chart dep and image to 2.2.1

### DIFF
--- a/helm/raster/Chart.yaml
+++ b/helm/raster/Chart.yaml
@@ -6,7 +6,7 @@ version: 6.6.1
 appVersion: 6.6.1
 dependencies:
   - name: nginx
-    version: 2.1.6
+    version: 2.2.1
     repository: oci://acrarolibotnonprod.azurecr.io/helm/common
   - name: mclabels
     version: 1.0.1

--- a/helm/raster/values.yaml
+++ b/helm/raster/values.yaml
@@ -129,10 +129,11 @@ resources:
 nginx:
   enabled: true
   fullnameOverride: ""
+  nameOverride: "pycsw-nginx"
   replicaCount: 2
   image:
     repository: common/nginx
-    tag: "v2.1.6"
+    tag: "v2.2.1"
   nginx:
     extensions:
       server:


### PR DESCRIPTION
## Summary
Upgrades the nginx dependency for the **raster** helm chart (`helm/raster`).

- Bump nginx chart dependency `2.1.6` → `2.2.1` (`helm/raster/Chart.yaml`)
- Bump nginx image tag `v2.1.6` → `v2.2.1` (`helm/raster/values.yaml`)
- Add `nginx.nameOverride: "pycsw-nginx"` (`helm/raster/values.yaml`)

