### PR TITLE
chore(helm): upgrade raster nginx chart to 2.3.1 and drop pinned image tag (MAPCO-11293)

### DIFF
--- a/helm/raster/Chart.yaml
+++ b/helm/raster/Chart.yaml
@@ -6,7 +6,7 @@ version: 6.7.1
 appVersion: 6.7.1
 dependencies:
   - name: nginx
-    version: 2.2.1
+    version: 2.3.1
     repository: oci://acrarolibotnonprod.azurecr.io/helm/common
   - name: mclabels
     version: 1.0.1

--- a/helm/raster/values.yaml
+++ b/helm/raster/values.yaml
@@ -133,7 +133,6 @@ nginx:
   replicaCount: 2
   image:
     repository: common/nginx
-    tag: "v2.2.1"
   nginx:
     extensions:
       server:


### PR DESCRIPTION
## Description

- Upgrade the `nginx` chart dependency in `helm/raster/Chart.yaml` from 2.2.1 to 2.3.1.
- Remove the pinned `nginx.image.tag` from `helm/raster/values.yaml` so the image tag falls back to the chart's default.