### PR TITLE
fix: raster log scraping typo (MAPCO-11293)

### DIFF
--- a/helm/raster/values.yaml
+++ b/helm/raster/values.yaml
@@ -33,7 +33,7 @@ mclabels:
   prometheus:
     enabled: true
     port: 9117
-  longScraping: true
+  logScraping: true
 
 enabled: true
 environment: development


### PR DESCRIPTION
This pull request makes a minor update to the `helm/raster/values.yaml` configuration file, correcting a parameter name for Prometheus scraping.

- Renamed the `longScraping` parameter to `logScraping` under the `prometheus` section to accurately reflect its purpose.